### PR TITLE
Fix mobile login functionality

### DIFF
--- a/frontend/src/component/Nav.jsx
+++ b/frontend/src/component/Nav.jsx
@@ -72,7 +72,7 @@ function Nav() {
         <div className='w-[100vw] h-[90px] flex items-center justify-between px-[20px] text-[12px]
          fixed bottom-0 left-0 bg-[#191818]   md:hidden'>
             <button className='text-[white] flex items-center justify-center flex-col gap-[2px]' onClick={()=>navigate("/")}><IoMdHome className='w-[28px] h-[28px] text-[white] md:hidden'/> Home</button>
-             <button className='text-[white] flex items-center justify-center flex-col gap-[2px]' onClick={()=>navigate("collection")}><HiOutlineCollection className='w-[28px] h-[28px] text-[white] md:hidden'/> Collections</button>
+             <button className='text-[white] flex items-center justify-center flex-col gap-[2px]' onClick={()=>navigate("/collection")}><HiOutlineCollection className='w-[28px] h-[28px] text-[white] md:hidden'/> Collections</button>
               <button className='text-[white] flex items-center justify-center flex-col gap-[2px] ' onClick={()=>navigate("/contact")}><MdContacts className='w-[28px] h-[28px] text-[white] md:hidden'/>Contact</button>
                <button className='text-[white] flex items-center justify-center flex-col gap-[2px]' onClick={()=>navigate("/cart")}><MdOutlineShoppingCart className='w-[28px] h-[28px] text-[white] md:hidden'/> Cart</button>
                <p className='absolute w-[18px] h-[18px] flex items-center justify-center bg-white px-[5px] py-[2px] text-black font-semibold  rounded-full text-[9px] top-[8px] right-[18px]'>{getCartCount()}</p>


### PR DESCRIPTION
Update mobile 'Collections' navigation to use an absolute path to prevent incorrect relative routing after login.

Previously, the relative path `collection` could lead to incorrect URLs like `/productdetail/collection` when navigating from certain pages, resulting in a blank page for users, especially after logging in on mobile.